### PR TITLE
Add MetaJSON plugin

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,4 +9,5 @@ copyright_holder = Kang-min Liu
 boolean = 0.20
 [PodWeaver]
 [@Classic]
+[MetaJSON]
 


### PR DESCRIPTION
The META.json file should be generated to provide [CPAN::Meta::Spec](https://metacpan.org/pod/CPAN::Meta::Spec) version 2 metadata. I recommend adding this plugin to any of your dist.ini using `@Classic` or `@Basic`, you could also consider [@Starter](https://metacpan.org/pod/Dist::Zilla::PluginBundle::Starter) which includes it for the future.